### PR TITLE
Add compatibility with Canvas, restore fabulous graphics compatibliity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,13 @@ repositories {
     maven(url = "https://maven.sk89q.com/repo") {
         name = "sk89q"
     }
+    maven(url = "https://grondag-repo.appspot.com") {
+        name = "grondag"
+        credentials {
+            username = "guest"
+            password = ""
+        }
+    }
 }
 
 java {
@@ -30,6 +37,8 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
     modImplementation("io.github.prospector:modmenu:$modmenuVersion")
     compileOnly("com.google.code.findbugs:jsr305:3.0.2") // compiler will crash without?
+
+    modImplementation("grondag:frex-mc116:3.1+") // for render event
 
     // for development environment
     modRuntime("com.sk89q.worldedit:worldedit-fabric-mc$minecraftVersion:7.2.0-SNAPSHOT") {

--- a/src/main/java/com/mumfrey/worldeditcui/event/listeners/CUIListenerWorldRender.java
+++ b/src/main/java/com/mumfrey/worldeditcui/event/listeners/CUIListenerWorldRender.java
@@ -5,8 +5,8 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mumfrey.worldeditcui.WorldEditCUI;
 import com.mumfrey.worldeditcui.util.Vector3;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.Framebuffer;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
 
 /**
  * Listener for WorldRenderEvent
@@ -17,9 +17,9 @@ import org.lwjgl.opengl.GL11;
  */
 public class CUIListenerWorldRender
 {
-	private WorldEditCUI controller;
+	private final WorldEditCUI controller;
 
-	private MinecraftClient minecraft;
+	private final MinecraftClient minecraft;
 
 	public CUIListenerWorldRender(WorldEditCUI controller, MinecraftClient minecraft)
 	{
@@ -29,16 +29,9 @@ public class CUIListenerWorldRender
 
 	public void onRender(float partialTicks)
 	{
-		Framebuffer buffer = null;
-		if(MinecraftClient.isFabulousGraphicsOrBetter()) {
-			buffer = MinecraftClient.getInstance().worldRenderer.getTranslucentFramebuffer();
-		}
-		if(buffer != null) {
-			buffer.beginWrite(false);
-		}
 		try
 		{
-			RenderSystem.glMultiTexCoord2f(33985, 240.0F, 240.0F);
+			RenderSystem.glMultiTexCoord2f(GL13.GL_TEXTURE1, 240.0F, 240.0F);
 			RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 			RenderSystem.enableBlend();
 			RenderSystem.enableAlphaTest();
@@ -66,11 +59,8 @@ public class CUIListenerWorldRender
 			RenderSystem.enableTexture();
 			RenderSystem.disableBlend();
 			RenderSystem.alphaFunc(GL11.GL_GREATER, 0.1F);
-		} catch (Exception ex) {
-		} finally {
-			if (buffer != null) {
-				buffer.endWrite();
-			}
+		} catch (Exception ex)
+		{
 		}
 	}
 }

--- a/src/main/java/eu/mikroskeem/worldeditcui/FabricModWorldEditCUI.java
+++ b/src/main/java/eu/mikroskeem/worldeditcui/FabricModWorldEditCUI.java
@@ -49,11 +49,12 @@ public final class FabricModWorldEditCUI implements ModInitializer {
     private ClientPlayerEntity lastPlayer;
 
     private boolean visible = true;
-    private boolean alwaysOnTop = false;
     private int delayedHelo = 0;
+    private static RenderMode activeRenderMode;
 
     /**
      * Register a key binding
+     *
      * @param name id, will be used as a localization key under {@code key.worldeditcui.<name>}
      * @param type type
      * @param code default value
@@ -61,6 +62,14 @@ public final class FabricModWorldEditCUI implements ModInitializer {
      */
     private static KeyBinding key(final String name, final InputUtil.Type type, final int code) {
         return KeyBindingHelper.registerKeyBinding(new KeyBinding("key." + MOD_ID + '.' + name, type, code, KEYBIND_CATEGORY_WECUI));
+    }
+
+    public static RenderMode getRenderMode() {
+        return activeRenderMode;
+    }
+
+    /* package */ static void setRenderMode(final RenderMode mode) {
+        activeRenderMode = mode;
     }
 
     @Override
@@ -103,7 +112,9 @@ public final class FabricModWorldEditCUI implements ModInitializer {
         }
 
         if (inGame && clock && controller != null) {
-            this.alwaysOnTop = config.isAlwaysOnTop();
+            if (activeRenderMode != RenderMode.FREX_POST_RENDER) {
+                activeRenderMode = config.isAlwaysOnTop() ? RenderMode.ALWAYS_ON_TOP : RenderMode.STANDARD;
+            }
 
             if (mc.world != this.lastWorld || mc.player != this.lastPlayer) {
                 this.lastWorld = mc.world;
@@ -155,13 +166,14 @@ public final class FabricModWorldEditCUI implements ModInitializer {
     }
 
     public void onPostRenderEntities(float partialTicks) {
-        if (this.visible && !this.alwaysOnTop) {
+        if (this.visible && activeRenderMode != RenderMode.ALWAYS_ON_TOP) {
             worldRenderListener.onRender(partialTicks);
         }
     }
 
     public void onPostRender(float partialTicks) {
-        if (this.visible && this.alwaysOnTop) {
+        // TODO: implement this?
+        if (this.visible && activeRenderMode == RenderMode.ALWAYS_ON_TOP) {
             worldRenderListener.onRender(partialTicks);
         }
     }

--- a/src/main/java/eu/mikroskeem/worldeditcui/FrexRenderHook.java
+++ b/src/main/java/eu/mikroskeem/worldeditcui/FrexRenderHook.java
@@ -1,0 +1,21 @@
+package eu.mikroskeem.worldeditcui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import grondag.frex.Frex;
+import grondag.frex.FrexInitializer;
+import grondag.frex.api.event.WorldRenderEvent;
+
+public class FrexRenderHook implements FrexInitializer {
+    @Override
+    public void onInitalizeFrex() {
+        if(Frex.isAvailable()) {
+            FabricModWorldEditCUI.setRenderMode(RenderMode.FREX_POST_RENDER);
+            WorldRenderEvent.AFTER_WORLD_RENDER.register((matrices, tickDelta, limitTime, renderBlockOutline, camera, gameRenderer, lightmapTextureManager, matrix4f) -> {
+                RenderSystem.pushMatrix();
+                RenderSystem.multMatrix(matrices.peek().getModel());
+                FabricModWorldEditCUI.getInstance().onPostRenderEntities(tickDelta);
+                RenderSystem.popMatrix();
+            });
+        }
+    }
+}

--- a/src/main/java/eu/mikroskeem/worldeditcui/RenderMode.java
+++ b/src/main/java/eu/mikroskeem/worldeditcui/RenderMode.java
@@ -1,0 +1,24 @@
+package eu.mikroskeem.worldeditcui;
+
+import grondag.frex.api.event.WorldRenderEvent;
+
+/**
+ * The active render hook being used for this CUI instance
+ */
+public enum RenderMode {
+    /**
+     * Standard hook into WorldRenderer
+     */
+    STANDARD,
+    /**
+     * Always render on top. Not currently implemented
+     */
+    ALWAYS_ON_TOP,
+
+    /**
+     * Use the frex {@link WorldRenderEvent#AFTER_WORLD_RENDER} hook to render.
+     *
+     * <p>This is more compatible with rendering mods, but produces worse results on <em>Fabulous</em> graphics mode.</p>
+     */
+    FREX_POST_RENDER
+}

--- a/src/main/java/eu/mikroskeem/worldeditcui/mixins/WorldRendererMixin.java
+++ b/src/main/java/eu/mikroskeem/worldeditcui/mixins/WorldRendererMixin.java
@@ -1,6 +1,9 @@
 package eu.mikroskeem.worldeditcui.mixins;
 
 import eu.mikroskeem.worldeditcui.FabricModWorldEditCUI;
+import eu.mikroskeem.worldeditcui.RenderMode;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.LightmapTextureManager;
@@ -8,9 +11,13 @@ import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
 
 /**
  * @author Mark Vainomaa
@@ -18,14 +25,37 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = WorldRenderer.class)
 public abstract class WorldRendererMixin {
 
+    @Shadow @Nullable private Framebuffer translucentFramebuffer;
+
+    @Inject(method = "render", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/client/gl/ShaderEffect;render(F)V"
+    ), slice = @Slice(from = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/render/WorldRenderer;renderWorldBorder(Lnet/minecraft/client/render/Camera;)V")))
+    private void afterRenderEntitiesFabulous(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline,
+                                            Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager,
+                                            Matrix4f matrix4f, CallbackInfo ci) {
+        // We are within a fabulous graphics check block
+        if (this.translucentFramebuffer != null && FabricModWorldEditCUI.getRenderMode() != RenderMode.FREX_POST_RENDER) {
+            this.translucentFramebuffer.beginWrite(false); // Same logic as RenderPhase.TRANSLUCENT_TARGET, but that's protected
+            try {
+                FabricModWorldEditCUI.getInstance().onPostRenderEntities(tickDelta);
+            } finally {
+                MinecraftClient.getInstance().getFramebuffer().beginWrite(false);
+            }
+        }
+    }
+
     @Inject(method = "render", at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/render/WorldRenderer;renderChunkDebugInfo(Lnet/minecraft/client/render/Camera;)V",
             shift = At.Shift.BEFORE
     ))
-    private void afterRenderEntitiesRegular(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline,
+    private void beforeChunkDebugInfo(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline,
                                      Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager,
                                      Matrix4f matrix4f, CallbackInfo ci) {
-        FabricModWorldEditCUI.getInstance().onPostRenderEntities(tickDelta);
+        if (this.translucentFramebuffer == null && FabricModWorldEditCUI.getRenderMode() != RenderMode.FREX_POST_RENDER) {
+            FabricModWorldEditCUI.getInstance().onPostRenderEntities(tickDelta);
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
     ],
     "modmenu": [
       "eu.mikroskeem.worldeditcui.gui.ConfigPanelFactory"
+    ],
+    "frex": [
+      "eu.mikroskeem.worldeditcui.FrexRenderHook"
     ]
   },
   "mixins": [


### PR DESCRIPTION
So it turns out baf4eb19a884ea04029e3645b4853e01d27595a2 changed the render hook injection point, and wasn't present on the 1.16 branch. The point it changed to is at a better point when everything is rendered in one framebuffer, but occurs after the fabulous mode framebuffers are all rendered, so nothing appeared.

I've also added in a hook using the [FREX](https://github.com/grondag/frex) library as the rendering point -- it's an API mod providing defined rendering hooks, and lets WECUI be compatible with the Canvas rendering mod. The point in the render loop that  `AFTER_WORLD_RENDER` targets is unfortunately a bit late for fabulous graphics, so we can't access the translucent buffer, meaning regions are drawn without using hidden lines. Because of this limitation, the FREX event is only used when a specifically FREX-compatible render is present, under the assumption that such a renderer would already entirely replace the `WorldRenderer#render` method, breaking WECUI's own mixins.