### PR TITLE
Fix multiconnect detection

### DIFF
--- a/src/main/java/eu/mikroskeem/worldeditcui/CUINetworking.java
+++ b/src/main/java/eu/mikroskeem/worldeditcui/CUINetworking.java
@@ -3,6 +3,7 @@ package eu.mikroskeem.worldeditcui;
 import net.earthcomputer.multiconnect.api.MultiConnectAPI;
 import net.earthcomputer.multiconnect.api.Protocols;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
@@ -15,25 +16,12 @@ import net.minecraft.util.Identifier;
  */
 final class CUINetworking {
 
-    private static final boolean MULTICONNECT_AVAILABLE;
+    private static final boolean MULTICONNECT_AVAILABLE = FabricLoader.getInstance().isModLoaded("multiconnect");
 
     private static final String CHANNEL_LEGACY = "WECUI"; // pre-1.13 channel name
     public static final Identifier CHANNEL_WECUI = new Identifier("worldedit", "cui");
 
-    static {
-        MULTICONNECT_AVAILABLE = isMultiConnectAvailable();
-    }
-
     private CUINetworking() {
-    }
-
-    private static boolean isMultiConnectAvailable() {
-        try {
-            Class.forName("net.earthcomputer.multiconnect.api.MultiConnectAPI");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false; // MultiConnect not installed
-        }
     }
 
     public static void send(final ClientPlayNetworkHandler handler, final PacketByteBuf codec) {


### PR DESCRIPTION
Mutliconnect API is a separate lightweight mod that other mods can jar in jar, and works with or without multiconnect installed. This API is backwards compatible but not forwards compatible, meaning that if some 3rd party mod packages an old version of the API, and no other mods package a newer version, WECUI can crash because it uses newer API classes.
The preferred solution has always been to jar in jar multiconnect API yourself, and fabric loader will pick the newest API version for you and everything should work. Otherwise, I have PRed a fixed multiconnect detection, which guarantees the latest version of multiconnect API so long as the user has the latest multiconnect version installed.

This fixes the following crash: https://paste.ee/p/62Tc8