### PR TITLE
Update to 1.18.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
     id("de.jjohannes.missing-metadata-guava") version "0.5"
 }
 
-val minecraftVersion = "1.18.1"
-val fabricLoaderVersion = "0.12.12"
-val fabricApiVersion = "0.44.0+1.18"
+val minecraftVersion = "1.18.2"
+val fabricLoaderVersion = "0.13.3"
+val fabricApiVersion = "0.47.10+1.18.2"
 val modmenuVersion = "3.0.0"
 val multiconnectVersion = "1.5.6"
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
     "fabric-key-binding-api-v1": "^1.0.0",
     "fabric-networking-api-v1": "*",
     "fabric-rendering-v1": ">=1.5.0",
-    "fabric-lifecycle-events-v1": "^1.0.0",
+    "fabric-lifecycle-events-v1": "^2.0.0",
     "minecraft": ">=1.18.1"
   },
   "suggests": {


### PR DESCRIPTION
Full disclosure: I have no idea what I'm doing with Fabric, but it seems to work fine with just these changes
fabric-lifecycle-events seemed to have bumped the major version in 1.18.2.

You can test it by downloading https://github.com/EngineHub/WorldEditCUI/suites/5564213236/artifacts/179807836